### PR TITLE
Support for zone controller

### DIFF
--- a/components/fujitsu-halcyon/Controller.h
+++ b/components/fujitsu-halcyon/Controller.h
@@ -55,9 +55,26 @@ namespace SettableFields {
     };
 };
 
+namespace ZoneSettableFields {
+    enum {
+        Zone1,
+        Zone2,
+        Zone3,
+        Zone4,
+        Zone5,
+        Zone6,
+        Zone7,
+        Zone8,
+        ZoneGroupDay,
+        ZoneGroupNight,
+        MAX
+    };
+};
+
 class Controller {
     using ConfigCallback = std::function<void(const Config&)>;
     using ErrorCallback  = std::function<void(const Packet&)>;
+    using ZoneConfigCallback = std::function<void(const ZoneConfig&)>;
     using ControllerConfigCallback = std::function<void(const uint8_t address, const Config&)>;
     using ReadBytesCallback  = std::function<void(uint8_t *data, size_t len)>;
     using WriteBytesCallback = std::function<void(const uint8_t *data, size_t len)>;
@@ -65,6 +82,7 @@ class Controller {
     struct Callbacks {
         ConfigCallback Config;
         ErrorCallback Error;
+        ZoneConfigCallback ZoneConfig;
         ControllerConfigCallback ControllerConfig;
         ReadBytesCallback ReadBytes;
         WriteBytesCallback WriteBytes;
@@ -78,6 +96,7 @@ class Controller {
         bool is_initialized() const { return this->initialization_stage == InitializationStageEnum::Complete; }
         void reinitialize() { this->initialization_stage = InitializationStageEnum::FeatureRequest; }
         const struct Features& get_features() const { return this->features; }
+        const struct ZoneFunction& get_zone_function() const { return this->zone_function; }
 
         void set_current_temperature(float temperature);
         bool set_enabled(bool enabled, bool ignore_lock = false);
@@ -88,6 +107,9 @@ class Controller {
         bool set_fan_speed(FanSpeedEnum fan_speed, bool ignore_lock = false);
         bool set_vertical_swing(bool swing_vertical, bool ignore_lock = false);
         bool set_horizontal_swing(bool swing_horizontal, bool ignore_lock = false);
+        bool set_zone(int zone_number, bool zone_active, bool ignore_lock = false);
+        bool set_zone_group_day(bool zone_group_active, bool ignore_lock = false);
+        bool set_zone_group_night(bool zone_group_active, bool ignore_lock = false);
         bool advance_vertical_louver(bool ignore_lock = false);
         bool advance_horizontal_louver(bool ignore_lock = false);
         bool use_sensor(bool use_sensor, bool ignore_lock = false);
@@ -110,7 +132,11 @@ class Controller {
         struct Features features = {};
         struct Config current_configuration = {};
         struct Config changed_configuration = {};
+        struct ZoneConfig current_zone_configuration = {};
+        struct ZoneConfig changed_zone_configuration = {};
+        struct ZoneFunction zone_function = {};
         std::bitset<SettableFields::MAX> configuration_changes;
+        std::bitset<ZoneSettableFields::MAX> zone_configuration_changes;
         bool last_error_flag = false; // TODO handle errors for multiple indoor units...multiple errors per IU?
 
         [[noreturn]] void uart_event_task();

--- a/components/fujitsu-halcyon/Packet.cpp
+++ b/components/fujitsu-halcyon/Packet.cpp
@@ -97,6 +97,36 @@ Packet::Packet(Buffer buffer) {
 
         case PacketTypeEnum::Status:
             break;
+
+        case PacketTypeEnum::ZoneConfig:
+            if (this->SourceType == AddressTypeEnum::IndoorUnit) {
+                // We don't worry about checking if they are enabled as a feature as the payload is complete
+                this->ZoneConfig.ActiveZones.Zone1 = getField(BMS.ZoneConfig.ActiveZones.Zone1);
+                this->ZoneConfig.ActiveZones.Zone2 = getField(BMS.ZoneConfig.ActiveZones.Zone2);
+                this->ZoneConfig.ActiveZones.Zone3 = getField(BMS.ZoneConfig.ActiveZones.Zone3);
+                this->ZoneConfig.ActiveZones.Zone4 = getField(BMS.ZoneConfig.ActiveZones.Zone4);
+                this->ZoneConfig.ActiveZones.Zone5 = getField(BMS.ZoneConfig.ActiveZones.Zone5);
+                this->ZoneConfig.ActiveZones.Zone6 = getField(BMS.ZoneConfig.ActiveZones.Zone6);
+                this->ZoneConfig.ActiveZones.Zone7 = getField(BMS.ZoneConfig.ActiveZones.Zone7);
+                this->ZoneConfig.ActiveZones.Zone8 = getField(BMS.ZoneConfig.ActiveZones.Zone8);
+                
+                this->ZoneConfig.ActiveZoneGroups.Day = getField(BMS.ZoneConfig.ActiveZoneGroups.Day);
+                this->ZoneConfig.ActiveZoneGroups.Night = getField(BMS.ZoneConfig.ActiveZoneGroups.Night);
+            }
+            break;
+
+        case PacketTypeEnum::ZoneFunction: // Use for hints to setup traits automatically
+            if (this->SourceType == AddressTypeEnum::IndoorUnit) {
+                this->ZoneFunction.EnabledZones.Zone1 = getField(BMS.ZoneFunction.EnabledZones.Zone1);
+                this->ZoneFunction.EnabledZones.Zone2 = getField(BMS.ZoneFunction.EnabledZones.Zone2);
+                this->ZoneFunction.EnabledZones.Zone3 = getField(BMS.ZoneFunction.EnabledZones.Zone3);
+                this->ZoneFunction.EnabledZones.Zone4 = getField(BMS.ZoneFunction.EnabledZones.Zone4);
+                this->ZoneFunction.EnabledZones.Zone5 = getField(BMS.ZoneFunction.EnabledZones.Zone5);
+                this->ZoneFunction.EnabledZones.Zone6 = getField(BMS.ZoneFunction.EnabledZones.Zone6);
+                this->ZoneFunction.EnabledZones.Zone7 = getField(BMS.ZoneFunction.EnabledZones.Zone7);
+                this->ZoneFunction.EnabledZones.Zone8 = getField(BMS.ZoneFunction.EnabledZones.Zone8);
+            }
+            break;
     }
 };
 
@@ -200,6 +230,26 @@ Packet::Buffer Packet::to_buffer() const {
             break;
 
         case PacketTypeEnum::Status:
+            break;
+
+        case PacketTypeEnum::ZoneConfig:
+            if (SourceType == AddressTypeEnum::Controller)
+                setField(BMS.ZoneConfig.Controller.Write, this->ZoneConfig.Controller.Write);
+
+            setField(BMS.ZoneConfig.ActiveZones.Zone1, this->ZoneConfig.ActiveZones.Zone1);
+            setField(BMS.ZoneConfig.ActiveZones.Zone2, this->ZoneConfig.ActiveZones.Zone2);
+            setField(BMS.ZoneConfig.ActiveZones.Zone3, this->ZoneConfig.ActiveZones.Zone3);
+            setField(BMS.ZoneConfig.ActiveZones.Zone4, this->ZoneConfig.ActiveZones.Zone4);
+            setField(BMS.ZoneConfig.ActiveZones.Zone5, this->ZoneConfig.ActiveZones.Zone5);
+            setField(BMS.ZoneConfig.ActiveZones.Zone6, this->ZoneConfig.ActiveZones.Zone6);
+            setField(BMS.ZoneConfig.ActiveZones.Zone7, this->ZoneConfig.ActiveZones.Zone7);
+            setField(BMS.ZoneConfig.ActiveZones.Zone8, this->ZoneConfig.ActiveZones.Zone8);
+
+            setField(BMS.ZoneConfig.ActiveZoneGroups.Day, this->ZoneConfig.ActiveZoneGroups.Day);
+            setField(BMS.ZoneConfig.ActiveZoneGroups.Night, this->ZoneConfig.ActiveZoneGroups.Night);
+            break;
+
+        case PacketTypeEnum::ZoneFunction:
             break;
     }
 

--- a/components/fujitsu-halcyon/Packet.h
+++ b/components/fujitsu-halcyon/Packet.h
@@ -19,7 +19,9 @@ enum class PacketTypeEnum : uint8_t {
     Error,
     Features,
     Function,
-    Status
+    Status,
+    ZoneConfig,
+    ZoneFunction
 };
 
 enum class FanSpeedEnum : uint8_t {
@@ -37,6 +39,8 @@ enum class ModeEnum : uint8_t {
     Heat,
     Auto
 };
+
+
 
 struct Config {
     struct {
@@ -119,6 +123,41 @@ struct Function {
 
 struct Status {};
 
+struct ZoneConfig {
+    struct {
+        bool Write;
+    } Controller;
+    
+    struct {
+        bool Zone1;
+        bool Zone2;
+        bool Zone3;
+        bool Zone4;
+        bool Zone5;
+        bool Zone6;
+        bool Zone7;
+        bool Zone8;
+    } ActiveZones;
+    
+    struct {
+        bool Day;
+        bool Night;
+    } ActiveZoneGroups;
+};
+
+struct ZoneFunction {
+    struct {
+        bool Zone1;
+        bool Zone2;
+        bool Zone3;
+        bool Zone4;
+        bool Zone5;
+        bool Zone6;
+        bool Zone7;
+        bool Zone8;
+    } EnabledZones;
+};
+
 struct ByteMaskShiftData {
     constexpr ByteMaskShiftData(uint8_t byte, uint8_t mask) : byte(byte), mask(mask), shift(std::countr_zero(mask)) {};
 
@@ -168,9 +207,11 @@ constexpr struct BMS {
 
         constexpr static auto FanSpeed                  = ByteMaskShiftData(3, 0b01110000);
         constexpr static auto Mode                      = ByteMaskShiftData(3, 0b00001110);
+        constexpr static auto Zones                     = ByteMaskShiftData(3, 0b11111111);
         constexpr static auto Enabled                   = ByteMaskShiftData(3, 0b00000001);
         constexpr static auto Economy                   = ByteMaskShiftData(4, 0b10000000);
         constexpr static auto TestRun                   = ByteMaskShiftData(4, 0b01000000);
+        constexpr static auto ZoneGroup                 = ByteMaskShiftData(4, 0b00011001);
         constexpr static auto Setpoint                  = ByteMaskShiftData(4, 0b00011111);
         constexpr static auto SwingHorizontal           = ByteMaskShiftData(5, 0b00010000);
         constexpr static auto SwingVertical             = ByteMaskShiftData(5, 0b00000100);
@@ -216,6 +257,42 @@ constexpr struct BMS {
     } Function {};
 
     constexpr static struct Status_ {} Status {};
+
+    constexpr static struct ZoneConfig_ {
+        constexpr static struct Controller_ {
+            constexpr static auto Write                 = ByteMaskShiftData(2, 0b00001000);
+        } Controller {};
+        constexpr static struct ActiveZones_ {
+            constexpr static auto Zone1                 = ByteMaskShiftData(3, 0b00000001);
+            constexpr static auto Zone2                 = ByteMaskShiftData(3, 0b00000010);
+            constexpr static auto Zone3                 = ByteMaskShiftData(3, 0b00000100);
+            constexpr static auto Zone4                 = ByteMaskShiftData(3, 0b00001000);
+            constexpr static auto Zone5                 = ByteMaskShiftData(3, 0b00010000);
+            constexpr static auto Zone6                 = ByteMaskShiftData(3, 0b00100000);
+            constexpr static auto Zone7                 = ByteMaskShiftData(3, 0b01000000);
+            constexpr static auto Zone8                 = ByteMaskShiftData(3, 0b10000000);
+        } ActiveZones {};
+
+        constexpr static struct ActiveZoneGroups_ {
+            constexpr static auto Day                   = ByteMaskShiftData(4, 0b00001000);
+            constexpr static auto Night                 = ByteMaskShiftData(4, 0b00010000);
+        } ActiveZoneGroups {};
+    } ZoneConfig {};
+
+    constexpr static struct ZoneFunction_ {
+        constexpr static struct EnabledZones_ {
+            constexpr static auto Common                = ByteMaskShiftData(2, 0b00001000);
+            constexpr static auto Zone1                 = ByteMaskShiftData(3, 0b00000001);
+            constexpr static auto Zone2                 = ByteMaskShiftData(3, 0b00000010);
+            constexpr static auto Zone3                 = ByteMaskShiftData(3, 0b00000100);
+            constexpr static auto Zone4                 = ByteMaskShiftData(3, 0b00001000);
+            constexpr static auto Zone5                 = ByteMaskShiftData(3, 0b00010000);
+            constexpr static auto Zone6                 = ByteMaskShiftData(3, 0b00100000);
+            constexpr static auto Zone7                 = ByteMaskShiftData(3, 0b01000000);
+            constexpr static auto Zone8                 = ByteMaskShiftData(3, 0b10000000);
+        } EnabledZones {};
+    } ZoneFunction {};
+
 } BMS;
 static_assert(BMS.Type.shift == 4 && BMS.Features.FanSpeed.Low.shift == 3, "Shift values calculated incorrectly");
 
@@ -241,6 +318,8 @@ class Packet {
         struct Function Function {};
         struct Features Features {};
         struct Status Status {};
+        struct ZoneConfig ZoneConfig {};
+        struct ZoneFunction ZoneFunction {};
 
         static void invert_buffer(Buffer& buffer) { *reinterpret_cast<uint64_t*>(buffer.data()) = ~*reinterpret_cast<uint64_t*>(buffer.data()); };
 };

--- a/components/fujitsu-halcyon/climate.py
+++ b/components/fujitsu-halcyon/climate.py
@@ -24,7 +24,7 @@ from esphome.const import (
     UNIT_CELSIUS
 )
 
-CODEOWNERS = ["@Omniflux"]
+CODEOWNERS = ["@Omniflux", "@dymondj"]
 DEPENDENCIES = ["tzsp", "uart"]
 AUTO_LOAD = ["binary_sensor", "button", "climate", "sensor", "switch", "text_sensor", "tzsp"]
 
@@ -32,6 +32,14 @@ CONF_CONTROLLER_ADDRESS = "controller_address"
 CONF_TEMPERATURE_CONTROLLER_ADDRESS = "temperature_controller_address"
 CONF_TEMPERATURE_SENSOR = "temperature_sensor_id"
 CONF_USE_SENSOR = "use_sensor"
+CONF_ZONE_1 = "zone_1"
+CONF_ZONE_2 = "zone_2"
+CONF_ZONE_3 = "zone_3"
+CONF_ZONE_4 = "zone_4"
+CONF_ZONE_5 = "zone_5"
+CONF_ZONE_6 = "zone_6"
+CONF_ZONE_7 = "zone_7"
+CONF_ZONE_8 = "zone_8"
 CONF_IGNORE_LOCK = "ignore_lock"
 
 CONF_STANDBY_MODE = "standby_mode"
@@ -64,6 +72,38 @@ CONFIG_SCHEMA = climate.CLIMATE_SCHEMA.extend(
             CustomSwitch,
             entity_category=ENTITY_CATEGORY_CONFIG,
             default_restore_mode="RESTORE_DEFAULT_OFF"
+        ),
+        cv.Optional(CONF_ZONE_1, default={CONF_NAME: "Zone 1", CONF_INTERNAL: True}): switch.switch_schema(
+            CustomSwitch,
+            default_restore_mode="RESTORE_DEFAULT_ON"
+        ),
+        cv.Optional(CONF_ZONE_2, default={CONF_NAME: "Zone 2", CONF_INTERNAL: True}): switch.switch_schema(
+            CustomSwitch,
+            default_restore_mode="RESTORE_DEFAULT_ON"
+        ),
+        cv.Optional(CONF_ZONE_3, default={CONF_NAME: "Zone 3", CONF_INTERNAL: True}): switch.switch_schema(
+            CustomSwitch,
+            default_restore_mode="RESTORE_DEFAULT_ON"
+        ),
+        cv.Optional(CONF_ZONE_4, default={CONF_NAME: "Zone 4", CONF_INTERNAL: True}): switch.switch_schema(
+            CustomSwitch,
+            default_restore_mode="RESTORE_DEFAULT_ON"
+        ),
+        cv.Optional(CONF_ZONE_5, default={CONF_NAME: "Zone 5", CONF_INTERNAL: True}): switch.switch_schema(
+            CustomSwitch,
+            default_restore_mode="RESTORE_DEFAULT_ON"
+        ),
+        cv.Optional(CONF_ZONE_6, default={CONF_NAME: "Zone 6", CONF_INTERNAL: True}): switch.switch_schema(
+            CustomSwitch,
+            default_restore_mode="RESTORE_DEFAULT_ON"
+        ),
+        cv.Optional(CONF_ZONE_7, default={CONF_NAME: "Zone 7", CONF_INTERNAL: True}): switch.switch_schema(
+            CustomSwitch,
+            default_restore_mode="RESTORE_DEFAULT_ON"
+        ),
+        cv.Optional(CONF_ZONE_8, default={CONF_NAME: "Zone 8", CONF_INTERNAL: True}): switch.switch_schema(
+            CustomSwitch,
+            default_restore_mode="RESTORE_DEFAULT_ON"
         ),
         cv.Optional(CONF_REMOTE_SENSOR, default={CONF_NAME: "Remote Temperature Sensor", CONF_INTERNAL: True}): sensor.sensor_schema(
             Sensor,
@@ -138,6 +178,30 @@ async def to_code(config):
 
     varx = cg.Pvariable(config[CONF_USE_SENSOR][CONF_ID], var.use_sensor_switch)
     await switch.register_switch(varx, config[CONF_USE_SENSOR])
+
+    varx = cg.Pvariable(config[CONF_ZONE_1][CONF_ID], var.zone_1_switch)
+    await switch.register_switch(varx, config[CONF_ZONE_1])
+
+    varx = cg.Pvariable(config[CONF_ZONE_2][CONF_ID], var.zone_2_switch)
+    await switch.register_switch(varx, config[CONF_ZONE_2])
+
+    varx = cg.Pvariable(config[CONF_ZONE_3][CONF_ID], var.zone_3_switch)
+    await switch.register_switch(varx, config[CONF_ZONE_3])
+
+    varx = cg.Pvariable(config[CONF_ZONE_4][CONF_ID], var.zone_4_switch)
+    await switch.register_switch(varx, config[CONF_ZONE_4])
+
+    varx = cg.Pvariable(config[CONF_ZONE_5][CONF_ID], var.zone_5_switch)
+    await switch.register_switch(varx, config[CONF_ZONE_5])
+
+    varx = cg.Pvariable(config[CONF_ZONE_6][CONF_ID], var.zone_6_switch)
+    await switch.register_switch(varx, config[CONF_ZONE_6])
+
+    varx = cg.Pvariable(config[CONF_ZONE_7][CONF_ID], var.zone_7_switch)
+    await switch.register_switch(varx, config[CONF_ZONE_7])
+
+    varx = cg.Pvariable(config[CONF_ZONE_8][CONF_ID], var.zone_8_switch)
+    await switch.register_switch(varx, config[CONF_ZONE_8])
 
     varx = cg.Pvariable(config[CONF_ADVANCE_VERTICAL_LOUVER][CONF_ID], var.advance_vertical_louver_button)
     await button.register_button(varx, config[CONF_ADVANCE_VERTICAL_LOUVER])

--- a/components/fujitsu-halcyon/esphome-fujitsu-halcyon.cpp
+++ b/components/fujitsu-halcyon/esphome-fujitsu-halcyon.cpp
@@ -18,6 +18,7 @@ void FujitsuHalcyonController::setup() {
         {
             .Config = [this](const fujitsu_halcyon_controller::Config& data){ this->update_from_device(data); },
             .Error  = [this](const fujitsu_halcyon_controller::Packet& data){ this->update_from_device(data); },
+            .ZoneConfig = [this](const fujitsu_halcyon_controller::ZoneConfig& data){ this->update_from_device(data); },
             .ControllerConfig = [this](const uint8_t address, const fujitsu_halcyon_controller::Config& data){ this->update_from_controller(address, data); },
             .ReadBytes  = [this](uint8_t *buf, size_t length){
                 this->read_array(buf, length);
@@ -93,6 +94,7 @@ climate::ClimateTraits FujitsuHalcyonController::traits() {
     using namespace climate;
 
     auto features = this->controller->get_features();
+    auto zone_function = this->controller->get_zone_function();
     auto traits = ClimateTraits();
 
     // Target temperature / Setpoint
@@ -158,6 +160,34 @@ climate::ClimateTraits FujitsuHalcyonController::traits() {
         this->reset_filter_button->set_internal(false);
     }
 
+    // if (zone_function.EnabledZones.Zone1)
+    //     this->zone_1_switch->set_internal(false);
+
+    // if (zone_function.EnabledZones.Zone2)
+    //    this->zone_2_switch->set_internal(false);
+
+    // if (zone_function.EnabledZones.Zone3)
+    //     this->zone_3_switch->set_internal(false);
+
+    // if (zone_function.EnabledZones.Zone4)
+    //     this->zone_4_switch->set_internal(false);    
+
+    // if (zone_function.EnabledZones.Zone5)
+    //     this->zone_5_switch->set_internal(false);
+
+    // if (zone_function.EnabledZones.Zone6)
+    //     this->zone_6_switch->set_internal(false);
+        
+    // if (zone_function.EnabledZones.Zone7)
+    //     this->zone_7_switch->set_internal(false);
+        
+    // if (zone_function.EnabledZones.Zone8)
+    //     this->zone_8_switch->set_internal(false);
+
+    // temp
+    this->zone_1_switch->set_internal(false);
+    this->zone_2_switch->set_internal(false);
+    
     this->reinitialize_button->set_internal(false);
 
     return traits;
@@ -260,6 +290,40 @@ void FujitsuHalcyonController::update_from_device(const fujitsu_halcyon_controll
 
     if (need_to_publish)
         this->publish_state();
+}
+
+void FujitsuHalcyonController::update_from_device(const fujitsu_halcyon_controller::ZoneConfig& data) {
+    if (data.ActiveZones.Zone1 != this->zone_1_switch->state) {
+        this->zone_1_switch->publish_state(data.ActiveZones.Zone1);
+    }
+    if (data.ActiveZones.Zone2 != this->zone_2_switch->state) {
+        this->zone_2_switch->publish_state(data.ActiveZones.Zone2);
+    }
+    if (data.ActiveZones.Zone3 != this->zone_3_switch->state) {
+        this->zone_3_switch->publish_state(data.ActiveZones.Zone3);
+    }
+    if (data.ActiveZones.Zone4 != this->zone_4_switch->state) {
+        this->zone_4_switch->publish_state(data.ActiveZones.Zone4);
+    }
+    if (data.ActiveZones.Zone5 != this->zone_5_switch->state) {
+        this->zone_5_switch->publish_state(data.ActiveZones.Zone5);
+    }
+    if (data.ActiveZones.Zone6 != this->zone_6_switch->state) {
+        this->zone_6_switch->publish_state(data.ActiveZones.Zone6);
+    }
+    if (data.ActiveZones.Zone7 != this->zone_7_switch->state) {
+        this->zone_7_switch->publish_state(data.ActiveZones.Zone7);
+    }
+    if (data.ActiveZones.Zone8 != this->zone_8_switch->state) {
+        this->zone_8_switch->publish_state(data.ActiveZones.Zone8);
+    }
+
+    if (data.ActiveZoneGroups.Day != this->zone_group_day_switch->state) {
+        this->zone_group_day_switch->publish_state(data.ActiveZoneGroups.Day);
+    }
+    if (data.ActiveZoneGroups.Night != this->zone_group_night_switch->state) {
+        this->zone_group_night_switch->publish_state(data.ActiveZoneGroups.Night);
+    }
 }
 
 void FujitsuHalcyonController::update_from_device(const fujitsu_halcyon_controller::Packet& data) {

--- a/components/fujitsu-halcyon/esphome-fujitsu-halcyon.h
+++ b/components/fujitsu-halcyon/esphome-fujitsu-halcyon.h
@@ -53,6 +53,16 @@ class FujitsuHalcyonController : public Component, public climate::Climate, publ
         CustomButton* advance_vertical_louver_button = new CustomButton([this]() { this->controller->advance_vertical_louver(this->ignore_lock_); });
         CustomButton* advance_horizontal_louver_button = new CustomButton([this]() { this->controller->advance_horizontal_louver(this->ignore_lock_); });
         CustomSwitch* use_sensor_switch = new CustomSwitch([this](bool state) { return this->controller->use_sensor(state, this->ignore_lock_); });
+        CustomSwitch* zone_1_switch = new CustomSwitch([this](bool state) { return this->controller->set_zone(1, state, this->ignore_lock_); });
+        CustomSwitch* zone_2_switch = new CustomSwitch([this](bool state) { return this->controller->set_zone(2, state, this->ignore_lock_); });
+        CustomSwitch* zone_3_switch = new CustomSwitch([this](bool state) { return this->controller->set_zone(3, state, this->ignore_lock_); });
+        CustomSwitch* zone_4_switch = new CustomSwitch([this](bool state) { return this->controller->set_zone(4, state, this->ignore_lock_); });
+        CustomSwitch* zone_5_switch = new CustomSwitch([this](bool state) { return this->controller->set_zone(5, state, this->ignore_lock_); });
+        CustomSwitch* zone_6_switch = new CustomSwitch([this](bool state) { return this->controller->set_zone(6, state, this->ignore_lock_); });
+        CustomSwitch* zone_7_switch = new CustomSwitch([this](bool state) { return this->controller->set_zone(7, state, this->ignore_lock_); });
+        CustomSwitch* zone_8_switch = new CustomSwitch([this](bool state) { return this->controller->set_zone(8, state, this->ignore_lock_); });
+        CustomSwitch* zone_group_day_switch = new CustomSwitch([this](bool state) { return this->controller->set_zone_group_day(state, this->ignore_lock_); });
+        CustomSwitch* zone_group_night_switch = new CustomSwitch([this](bool state) { return this->controller->set_zone_group_night(state, this->ignore_lock_); });
 
         FujitsuHalcyonController(uart::IDFUARTComponent *parent, uint8_t controller_address) : uart::UARTDevice(parent), controller_address_(controller_address) {}
 
@@ -78,6 +88,7 @@ class FujitsuHalcyonController : public Component, public climate::Climate, publ
         fujitsu_halcyon_controller::Controller* controller;
 
         void update_from_device(const fujitsu_halcyon_controller::Config& data);
+        void update_from_device(const fujitsu_halcyon_controller::ZoneConfig& data);
         void update_from_device(const fujitsu_halcyon_controller::Packet& data);
         void update_from_controller(const uint8_t address, const fujitsu_halcyon_controller::Config& data);
 


### PR DESCRIPTION
Hi,

I've done some initial work to introduce zone controller functionality into this component.

Updated packet traces for controller communications are available at https://github.com/Omniflux/fujitsu-airstage-h-dissector/pull/1

Known issues:
- [ ] Hardcoded enabling zones 1 & 2 only - more can be enabled with a minor code update. The plan here is to read this config from the indoor unit at power on time so traits can be managed. This works but I'm having issues getting set_internal(false) to stick. I suspect RX interrupts are interfering.
- [ ] Verbose code handling zone interactions - could really do with a refactor or some thought from someone with a bit more depth in C++. Started looking at bitsets but ran into issues where the device is not responsive enough and causes the wall controller to throw an error. See https://github.com/dymondj/esphome-fujitsu-halcyon/tree/zones-refactor.
- [ ] No checks in-place to ensure at least one damper/zone remains active! This is currently managed locally at the wall controller but the indoor unit will happily accept a request to close all zones.

Hopefully I can get some pointers from the wider community above :)