### PR TITLE
Add supported_features diagnostic text sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The following entities are created automatically in Home Assistant. Feature-depe
 | Error | Binary sensor | Enabled | Indicates an active fault on the indoor unit |
 | Error Code | Text sensor | Enabled | Fault code in `AA BB` hex format (unit address + error code) |
 | Initialization Stage | Text sensor | Enabled | Current initialization progress, (4/4) indicates complete |
-| Supported Features | Text sensor | Disabled | List of features reported by the indoor unit, published once at initialization. Example: `Mode: Auto Heat Cool Dry Fan \| Fan: Auto High Medium Low Quiet \| Economy \| Sensor Switching \| V.Louvers \| H.Louvers` |
+| Supported Features | Text sensor | Enabled | List of features reported by the indoor unit, published once at initialization. Example: `Mode: Auto Heat Cool Dry Fan \| Fan: Auto High Medium Low Quiet \| Economy \| Sensor Switching \| V.Louvers \| H.Louvers` |
 | Remote Temperature Sensor | Sensor | Disabled | Temperature reported by another controller on the bus (see `temperature_controller_address`) |
 | Filter Timer Expired | Binary sensor | Feature-dependent | Set when the filter maintenance timer has elapsed |
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 An ESPHome component to control Fujitsu AirStage-H (product line previously known as Halcyon) units via the three wire (RWB) bus.
 
+> [!WARNING]
+> Requires ESPHome 2026.3.0 or newer.
+
 ```yaml
 substitutions:
   device_name: halcyon-controller
@@ -95,6 +98,38 @@ climate:
 If your unit supports sensor switching and has had the function settings set appropriately (see your installation manual, usually settings `42` and `48`), your unit can also be set to use this sensor instead of the sensor in its air intake. When available, a switch will appear in the Home Assistant device page in the Configuration section named `Use Sensor`
 
 Configure TZSP and use Wireshark with [fujitsu-airstage-h-dissector](https://github.com/Omniflux/fujitsu-airstage-h-dissector) to debug / decode the Fujitsu serial protocol.
+
+## Home Assistant entities
+
+The following entities are created automatically in Home Assistant. Feature-dependent entities (louvers, filter, sensor switching) are only exposed once the unit has reported its capabilities.
+
+### Climate
+| Entity | Type | Description |
+|--------|------|-------------|
+| *(friendly name)* | Climate | Main control: mode, fan speed, setpoint, swing, economy preset |
+
+### Diagnostics
+| Entity | Type | Default | Description |
+|--------|------|---------|-------------|
+| Connected | Binary sensor | Enabled | Whether the controller has completed initialization with the indoor unit |
+| Standby Mode | Binary sensor | Enabled | Active during defrost, oil recovery, or multi-unit synchronization |
+| Error | Binary sensor | Enabled | Indicates an active fault on the indoor unit |
+| Error Code | Text sensor | Enabled | Fault code in `AA BB` hex format (unit address + error code) |
+| Initialization Stage | Text sensor | Enabled | Current initialization progress, (4/4) indicates complete |
+| Supported Features | Text sensor | Disabled | List of features reported by the indoor unit, published once at initialization. Example: `Mode: Auto Heat Cool Dry Fan \| Fan: Auto High Medium Low Quiet \| Economy \| Sensor Switching \| V.Louvers \| H.Louvers` |
+| Remote Temperature Sensor | Sensor | Disabled | Temperature reported by another controller on the bus (see `temperature_controller_address`) |
+| Filter Timer Expired | Binary sensor | Feature-dependent | Set when the filter maintenance timer has elapsed |
+
+### Configuration
+| Entity | Type | Default | Description |
+|--------|------|---------|-------------|
+| Use Sensor | Switch | Feature-dependent | Route the external temperature sensor reading to the indoor unit (requires unit support and `temperature_sensor_id` configured, see settings `42` and `48`) |
+| Reset Filter Timer | Button | Feature-dependent | Reset the filter maintenance timer |
+| Advance Vertical Louver | Button | Feature-dependent | Step the vertical louver to the next position |
+| Advance Horizontal Louver | Button | Feature-dependent | Step the horizontal louver to the next position |
+| Reinitialize | Button | Enabled | Re-run the initialization sequence without rebooting |
+| Function / Function Value / Function Unit | Number | Enabled | Raw function register access |
+| Function_Read / Function_Write | Button | Enabled / Disabled | Trigger a function register read or write |
 
 ## Related projects
 - FOSV's [Fuji-Atom-Interface](https://github.com/FOSV/Fuji-Atom-Interface) - Open hardware interface compatible with this component

--- a/components/fujitsu-halcyon/climate.py
+++ b/components/fujitsu-halcyon/climate.py
@@ -67,6 +67,7 @@ CONF_RESET_FILTER_TIMER = "reset_filter_timer"
 CONF_FILTER_TIMER_EXPIRED = "filter_timer_expired"
 CONF_REINITIALIZE = "reinitialize"
 CONF_CONNECTED = "connected"
+CONF_SUPPORTED_FEATURES = "supported_features"
 
 CONF_FUNCTION = "function"
 CONF_FUNCTION_VALUE = "function_value"
@@ -169,7 +170,11 @@ CONFIG_SCHEMA = climate.climate_schema(FujitsuHalcyonController).extend(
             BinarySensor,
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
             device_class=DEVICE_CLASS_CONNECTIVITY
-        )
+        ),
+        cv.Optional(CONF_SUPPORTED_FEATURES, default={CONF_NAME: "Supported Features", CONF_DISABLED_BY_DEFAULT: True}): text_sensor.text_sensor_schema(
+            TextSensor,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC
+        ),
     }
 ).extend(cv.COMPONENT_SCHEMA).extend(uart.UART_DEVICE_SCHEMA)
 
@@ -278,6 +283,9 @@ async def to_code(config: ConfigType) -> None:
 
     varx = cg.Pvariable(config[CONF_CONNECTED][CONF_ID], var.connected_sensor)
     await binary_sensor.register_binary_sensor(varx, config[CONF_CONNECTED])
+
+    varx = cg.Pvariable(config[CONF_SUPPORTED_FEATURES][CONF_ID], var.supported_features_sensor)
+    await text_sensor.register_text_sensor(varx, config[CONF_SUPPORTED_FEATURES])
 
     varx = cg.Pvariable(config[CONF_REMOTE_SENSOR][CONF_ID], var.remote_sensor)
     await sensor.register_sensor(varx, config[CONF_REMOTE_SENSOR])

--- a/components/fujitsu-halcyon/climate.py
+++ b/components/fujitsu-halcyon/climate.py
@@ -171,7 +171,7 @@ CONFIG_SCHEMA = climate.climate_schema(FujitsuHalcyonController).extend(
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
             device_class=DEVICE_CLASS_CONNECTIVITY
         ),
-        cv.Optional(CONF_SUPPORTED_FEATURES, default={CONF_NAME: "Supported Features", CONF_DISABLED_BY_DEFAULT: True}): text_sensor.text_sensor_schema(
+        cv.Optional(CONF_SUPPORTED_FEATURES, default={CONF_NAME: "Supported Features"}): text_sensor.text_sensor_schema(
             TextSensor,
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC
         ),

--- a/components/fujitsu-halcyon/esphome-fujitsu-halcyon.cpp
+++ b/components/fujitsu-halcyon/esphome-fujitsu-halcyon.cpp
@@ -131,6 +131,35 @@ void FujitsuHalcyonController::on_initialization_stage(const fujitsu_general::ai
     // and force a state publish so HA discovers them even if ListEntities already ran
     auto features = this->controller->get_features();
 
+    // Publish supported features as a human-readable diagnostic string.
+    // Built with basic string concatenation — std::format is not available in ESPHome.
+    {
+        std::string s;
+
+        s += "Mode:";
+        if (features.Mode.Auto)   s += " Auto";
+        if (features.Mode.Heat)   s += " Heat";
+        if (features.Mode.Cool)   s += " Cool";
+        if (features.Mode.Dry)    s += " Dry";
+        if (features.Mode.Fan)    s += " Fan";
+
+        s += " | Fan:";
+        if (features.FanSpeed.Auto)   s += " Auto";
+        if (features.FanSpeed.High)   s += " High";
+        if (features.FanSpeed.Medium) s += " Medium";
+        if (features.FanSpeed.Low)    s += " Low";
+        if (features.FanSpeed.Quiet)  s += " Quiet";
+
+        if (features.EconomyMode)       s += " | Economy";
+        if (features.FilterTimer)       s += " | FilterTimer";
+        if (features.SensorSwitching)   s += " | Sensor Switching";
+        if (features.Maintenance)       s += " | Maintenance";
+        if (features.VerticalLouvers)   s += " | V.Louvers";
+        if (features.HorizontalLouvers) s += " | H.Louvers";
+
+        this->supported_features_sensor->publish_state(s);
+    }
+
     if (features.SensorSwitching && this->temperature_sensor_ != nullptr) {
         this->use_sensor_switch->set_internal(false);
         this->use_sensor_switch->publish_state(this->use_sensor_switch->state);
@@ -469,7 +498,7 @@ constexpr fujitsu_general::airstage::h::ModeEnum FujitsuHalcyonController::clima
         // Should not get to this point if traits is respected
         default: return FujitsuMode::Fan;
     }
-} 
+}
 
 constexpr fujitsu_general::airstage::h::FanSpeedEnum FujitsuHalcyonController::climate_fan_mode_to_fan_speed(climate::ClimateFanMode fan_speed) {
     using climate::ClimateFanMode;

--- a/components/fujitsu-halcyon/esphome-fujitsu-halcyon.cpp
+++ b/components/fujitsu-halcyon/esphome-fujitsu-halcyon.cpp
@@ -151,7 +151,7 @@ void FujitsuHalcyonController::on_initialization_stage(const fujitsu_general::ai
         if (features.FanSpeed.Quiet)  s += " Quiet";
 
         if (features.EconomyMode)       s += " | Economy";
-        if (features.FilterTimer)       s += " | FilterTimer";
+        if (features.FilterTimer)       s += " | Filter Timer";
         if (features.SensorSwitching)   s += " | Sensor Switching";
         if (features.Maintenance)       s += " | Maintenance";
         if (features.VerticalLouvers)   s += " | V.Louvers";

--- a/components/fujitsu-halcyon/esphome-fujitsu-halcyon.h
+++ b/components/fujitsu-halcyon/esphome-fujitsu-halcyon.h
@@ -33,6 +33,7 @@ class FujitsuHalcyonController : public Component, public climate::Climate, publ
         binary_sensor::BinarySensor* connected_sensor = new binary_sensor::BinarySensor();
         text_sensor::TextSensor* error_code_sensor = new text_sensor::TextSensor();
         text_sensor::TextSensor* initialization_sensor = new text_sensor::TextSensor();
+        text_sensor::TextSensor* supported_features_sensor = new text_sensor::TextSensor();
         sensor::Sensor* remote_sensor = new sensor::Sensor();
 
         custom::CustomButton* reinitialize_button = new custom::CustomButton([this]() { this->controller->reinitialize(); });


### PR DESCRIPTION
This PR adds a diagnostic text sensor that publishes the indoor unit's supported features as a human-readable string once initialization completes.

**Example output:**
```
Mode: Auto Heat Cool Dry Fan | Fan: Auto High Medium Low Quiet | Economy | Sensor Switching | V.Louvers | H.Louvers
```

After a power glitch, I experienced a situation where feature-dependent entities did not reappear in Home Assistant. I believe that issue is now corrected, but this sensor would have help the diagnosis.

Since `set_internal()` is deprecated and will be removed in ESPHome 2027.3.0, maybe the way to handle feature-dependent entities going forward will be to set them as `disabled_by_default` instead, and the user can activate them using this list as a reference. This is not as user-friendly as the current approach, but it may be the way going forward.