### PR TITLE
Add autoconf and per-feature overrides for units without feature negotiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,42 @@ If your unit supports sensor switching and has had the function settings set app
 
 Configure TZSP and use Wireshark with [fujitsu-airstage-h-dissector](https://github.com/Omniflux/fujitsu-airstage-h-dissector) to debug / decode the Fujitsu serial protocol.
 
+## Per-unit feature configuration
+
+By default the controller probes the indoor unit with a `FeatureRequest` packet and uses the unit's reported feature set. Some indoor units do not support feature negotiation: they advertise `UnknownFlags == 2` (handled automatically by falling through to in-code `DefaultFeatures`), or they ignore the `FeatureRequest` and keep replying with `Config` packets (also handled automatically since the first such `Config` is treated as "no negotiation support"). A small number of units have been observed to enter a non-recoverable error state when sent a `FeatureRequest`; for those, set `autoconf: false` to skip the probe entirely.
+
+When negotiation does not yield a `Features` packet, you can override the in-code defaults from YAML to match your specific indoor unit. Anything not specified keeps the in-code `DefaultFeatures` value.
+
+```yaml
+climate:
+  - platform: fujitsu-halcyon
+    name: None
+    controller_address: 0
+
+    # Skip the FeatureRequest probe entirely. Use this for units known to
+    # enter a non-recoverable error state when probed. Optional; default true.
+    autoconf: false
+
+    # Override the in-code DefaultFeatures. The IU's reported Features (if any)
+    # always wins; these values apply only when no Features packet arrives.
+    supported_modes:      [AUTO, COOL, HEAT, DRY, FAN]    # any subset
+    supported_fan_modes:  [AUTO, QUIET, LOW, MEDIUM, HIGH] # any subset
+    supported_swing_modes: [VERTICAL]                      # VERTICAL / HORIZONTAL / BOTH
+
+    filter_timer: true
+    sensor_switching: true
+    maintenance: true
+    economy_mode: true
+```
+
+Behavior matrix:
+
+| `autoconf` | IU sends `Features` | Result |
+|---|---|---|
+| `true` (default) | yes | IU's reported `Features` wins |
+| `true` | no | YAML overrides applied on top of `DefaultFeatures` |
+| `false` | (not probed) | YAML overrides applied on top of `DefaultFeatures` |
+
 ## Home Assistant entities
 
 The following entities are created automatically in Home Assistant. Feature-dependent entities (louvers, filter, sensor switching) are only exposed once the unit has reported its capabilities.

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ The following entities are created automatically in Home Assistant. Feature-depe
 | Standby Mode | Binary sensor | Enabled | Active during defrost, oil recovery, or multi-unit synchronization |
 | Error | Binary sensor | Enabled | Indicates an active fault on the indoor unit |
 | Error Code | Text sensor | Enabled | Fault code in `AA BB` hex format (unit address + error code) |
-| Initialization Stage | Text sensor | Enabled | Current initialization progress, (4/4) indicates complete |
+| Initialization Stage | Text sensor | Enabled | Current initialization progress, (5/5) indicates complete |
 | Supported Features | Text sensor | Enabled | List of features reported by the indoor unit, published once at initialization. Example: `Mode: Auto Heat Cool Dry Fan \| Fan: Auto High Medium Low Quiet \| Economy \| Sensor Switching \| V.Louvers \| H.Louvers` |
 | Remote Temperature Sensor | Sensor | Disabled | Temperature reported by another controller on the bus (see `temperature_controller_address`) |
 | Filter Timer Expired | Binary sensor | Feature-dependent | Set when the filter maintenance timer has elapsed |

--- a/components/fujitsu-halcyon/Controller.cpp
+++ b/components/fujitsu-halcyon/Controller.cpp
@@ -75,14 +75,17 @@ void Controller::process_packet(const Packet::Buffer& buffer, bool lastPacketOnW
             [[likely]] case PacketTypeEnum::Config:
                 if (this->initialization_stage == InitializationStageEnum::DetectFeatureSupport ||
                     this->initialization_stage == InitializationStageEnum::FeatureRequest) {
-                    // Advance to FindNextControllerTx if either:
+                    // Advance to FindNextControllerTx if any of:
+                    //  - autoconf is disabled (use the configured features directly),
                     //  - the IU's UnknownFlags == 2 (no feature negotiation support), or
                     //  - we already issued a FeatureRequest and the IU replied with Config
                     //    instead of Features (does not support feature negotiation).
                     // Otherwise, transition from DetectFeatureSupport to FeatureRequest to probe.
-                    if (packet.Config.IndoorUnit.UnknownFlags == 2 ||
+                    // Note: this->features is already initialized to DefaultFeatures (or to a
+                    // user-supplied override via set_features()), so no assignment is needed here.
+                    if (!this->autoconf ||
+                        packet.Config.IndoorUnit.UnknownFlags == 2 ||
                         this->initialization_stage == InitializationStageEnum::FeatureRequest) {
-                        this->features = DefaultFeatures;
                         this->set_initialization_stage(InitializationStageEnum::FindNextControllerTx);
                     } else
                         this->set_initialization_stage(InitializationStageEnum::FeatureRequest);

--- a/components/fujitsu-halcyon/Controller.cpp
+++ b/components/fujitsu-halcyon/Controller.cpp
@@ -73,8 +73,15 @@ void Controller::process_packet(const Packet::Buffer& buffer, bool lastPacketOnW
     if (packet.SourceType == AddressTypeEnum::IndoorUnit) {
         switch (packet.Type) {
             [[likely]] case PacketTypeEnum::Config:
-                if (this->initialization_stage == InitializationStageEnum::DetectFeatureSupport) {
-                    if (packet.Config.IndoorUnit.UnknownFlags == 2) { // Guessing this means no feature support among other things
+                if (this->initialization_stage == InitializationStageEnum::DetectFeatureSupport ||
+                    this->initialization_stage == InitializationStageEnum::FeatureRequest) {
+                    // Advance to FindNextControllerTx if either:
+                    //  - the IU's UnknownFlags == 2 (no feature negotiation support), or
+                    //  - we already issued a FeatureRequest and the IU replied with Config
+                    //    instead of Features (does not support feature negotiation).
+                    // Otherwise, transition from DetectFeatureSupport to FeatureRequest to probe.
+                    if (packet.Config.IndoorUnit.UnknownFlags == 2 ||
+                        this->initialization_stage == InitializationStageEnum::FeatureRequest) {
                         this->features = DefaultFeatures;
                         this->set_initialization_stage(InitializationStageEnum::FindNextControllerTx);
                     } else

--- a/components/fujitsu-halcyon/Controller.cpp
+++ b/components/fujitsu-halcyon/Controller.cpp
@@ -73,22 +73,27 @@ void Controller::process_packet(const Packet::Buffer& buffer, bool lastPacketOnW
     if (packet.SourceType == AddressTypeEnum::IndoorUnit) {
         switch (packet.Type) {
             [[likely]] case PacketTypeEnum::Config:
-                if (this->initialization_stage == InitializationStageEnum::DetectFeatureSupport ||
-                    this->initialization_stage == InitializationStageEnum::FeatureRequest) {
-                    // Advance to FindNextControllerTx if any of:
-                    //  - autoconf is disabled (use the configured features directly),
-                    //  - the IU's UnknownFlags == 2 (no feature negotiation support), or
-                    //  - we already issued a FeatureRequest and the IU replied with Config
-                    //    instead of Features (does not support feature negotiation).
-                    // Otherwise, transition from DetectFeatureSupport to FeatureRequest to probe.
+                if (this->initialization_stage == InitializationStageEnum::DetectFeatureSupport) {
+                    // Advance to FindNextControllerTx (skip feature negotiation entirely) if:
+                    //  - autoconf is disabled (use the configured features directly), or
+                    //  - the IU's UnknownFlags == 2 (no feature negotiation support).
+                    // Otherwise, transition to FeatureRequestTx to send a FeatureRequest packet
+                    // when our turn with the token comes around. The actual transmission and
+                    // the subsequent transition to FeatureRequestRx happen later in this function.
                     // Note: this->features is already initialized to DefaultFeatures (or to a
                     // user-supplied override via set_features()), so no assignment is needed here.
                     if (!this->autoconf ||
-                        packet.Config.IndoorUnit.UnknownFlags == 2 ||
-                        this->initialization_stage == InitializationStageEnum::FeatureRequest) {
+                        packet.Config.IndoorUnit.UnknownFlags == 2) {
                         this->set_initialization_stage(InitializationStageEnum::FindNextControllerTx);
                     } else
-                        this->set_initialization_stage(InitializationStageEnum::FeatureRequest);
+                        this->set_initialization_stage(InitializationStageEnum::FeatureRequestTx);
+                }
+                else if (this->initialization_stage == InitializationStageEnum::FeatureRequestRx) {
+                    // We already transmitted a FeatureRequest and the IU replied with another
+                    // Config instead of a Features packet -> the IU does not support feature
+                    // negotiation. Fall back to the in-code (or user-supplied) defaults already
+                    // present in this->features and proceed.
+                    this->set_initialization_stage(InitializationStageEnum::FindNextControllerTx);
                 }
 
                 if (this->last_error_flag != packet.Config.IndoorUnit.Error)
@@ -148,8 +153,12 @@ void Controller::process_packet(const Packet::Buffer& buffer, bool lastPacketOnW
         tx_packet.TokenDestinationType = this->next_token_destination_type;
         tx_packet.TokenDestinationAddress = this->next_token_destination_type == AddressTypeEnum::Controller ? this->controller_address + 1 : 1;
 
-        if (this->initialization_stage == InitializationStageEnum::FeatureRequest)
+        if (this->initialization_stage == InitializationStageEnum::FeatureRequestTx) {
             tx_packet.Type = PacketTypeEnum::Features;
+            // Advance only after the request is actually transmitted, mirroring
+            // the FindNextControllerTx -> FindNextControllerRx transition above.
+            this->set_initialization_stage(InitializationStageEnum::FeatureRequestRx);
+        }
         else if ((error_flag_changed && this->is_primary_controller()) ||
                  (packet.Type == PacketTypeEnum::Error && !this->is_primary_controller()))
             tx_packet.Type = PacketTypeEnum::Error;

--- a/components/fujitsu-halcyon/Controller.h
+++ b/components/fujitsu-halcyon/Controller.h
@@ -112,6 +112,19 @@ class Controller {
         InitializationStageEnum get_initialization_stage() const { return this->initialization_stage; }
         const struct Features& get_features() const { return this->features; }
 
+        // Override the in-code DefaultFeatures with a user-supplied Features struct.
+        // Used both as the initial fallback while probing and as the value applied
+        // when feature negotiation is skipped or unsupported.
+        // Must be called before the controller starts processing packets to take effect
+        // for the first IU Config received.
+        void set_features(const Features& features) { this->features = features; }
+
+        // Controls whether the controller probes the IU with a FeatureRequest packet.
+        // When false, the controller skips the FeatureRequest stage on the first IU
+        // Config and applies the configured features directly. Useful for IUs known
+        // to misbehave on FeatureRequest (e.g. enter a non-recoverable error state).
+        void set_autoconf(bool autoconf) { this->autoconf = autoconf; }
+
         void set_current_temperature(float temperature);
         bool set_enabled(bool enabled, bool ignore_lock = false);
         bool set_economy(bool economy, bool ignore_lock = false);
@@ -142,7 +155,8 @@ class Controller {
         uint8_t controller_address;
         Callbacks callbacks;
 
-        struct Features features = {};
+        bool autoconf = true;
+        struct Features features = DefaultFeatures;
         struct Config current_configuration = {};
         struct Config changed_configuration = {};
         std::bitset<SettableFields::MAX> configuration_changes;

--- a/components/fujitsu-halcyon/Controller.h
+++ b/components/fujitsu-halcyon/Controller.h
@@ -55,7 +55,8 @@ constexpr Features DefaultFeatures = {
 
 enum class InitializationStageEnum : uint8_t {
     DetectFeatureSupport,
-    FeatureRequest,
+    FeatureRequestTx,
+    FeatureRequestRx,
     FindNextControllerTx,
     FindNextControllerRx,
     Complete

--- a/components/fujitsu-halcyon/climate.py
+++ b/components/fujitsu-halcyon/climate.py
@@ -56,6 +56,26 @@ CONF_TEMPERATURE_SENSOR = "temperature_sensor_id"
 CONF_USE_SENSOR = "use_sensor"
 CONF_IGNORE_LOCK = "ignore_lock"
 
+# Feature negotiation override options.
+# When the indoor unit responds to a FeatureRequest with a Features packet, the
+# IU's reported feature set is used and these options are ignored. Use these
+# options when (a) the IU does not support feature negotiation (responds with
+# Config instead of Features, or has UnknownFlags == 2), or (b) you want to
+# disable probing entirely with `autoconf: false` for IUs known to misbehave on
+# FeatureRequest. Anything not specified keeps the in-code DefaultFeatures value.
+CONF_AUTOCONF = "autoconf"
+CONF_SUPPORTED_MODES = "supported_modes"
+CONF_SUPPORTED_FAN_MODES = "supported_fan_modes"
+CONF_SUPPORTED_SWING_MODES = "supported_swing_modes"
+CONF_FILTER_TIMER = "filter_timer"
+CONF_SENSOR_SWITCHING = "sensor_switching"
+CONF_MAINTENANCE = "maintenance"
+CONF_ECONOMY_MODE = "economy_mode"
+
+ALLOWED_MODES = {"AUTO", "HEAT", "FAN", "DRY", "COOL"}
+ALLOWED_FAN_MODES = {"QUIET", "LOW", "MEDIUM", "HIGH", "AUTO"}
+ALLOWED_SWING_MODES = {"VERTICAL", "HORIZONTAL", "BOTH"}
+
 CONF_STANDBY_MODE = "standby_mode"
 CONF_ERROR_CODE = "error_code"
 CONF_ERROR_STATE = "error_state"
@@ -98,6 +118,14 @@ CONFIG_SCHEMA = climate.climate_schema(FujitsuHalcyonController).extend(
         cv.Optional(CONF_IGNORE_LOCK, default=False): cv.boolean,
         cv.Optional(CONF_TEMPERATURE_SENSOR): cv.use_id(sensor.Sensor),
         cv.Optional(CONF_HUMIDITY_SENSOR): cv.use_id(sensor.Sensor),
+        cv.Optional(CONF_AUTOCONF): cv.boolean,
+        cv.Optional(CONF_SUPPORTED_MODES): cv.ensure_list(cv.one_of(*ALLOWED_MODES, upper=True)),
+        cv.Optional(CONF_SUPPORTED_FAN_MODES): cv.ensure_list(cv.one_of(*ALLOWED_FAN_MODES, upper=True)),
+        cv.Optional(CONF_SUPPORTED_SWING_MODES): cv.ensure_list(cv.one_of(*ALLOWED_SWING_MODES, upper=True)),
+        cv.Optional(CONF_FILTER_TIMER): cv.boolean,
+        cv.Optional(CONF_SENSOR_SWITCHING): cv.boolean,
+        cv.Optional(CONF_MAINTENANCE): cv.boolean,
+        cv.Optional(CONF_ECONOMY_MODE): cv.boolean,
         cv.Optional(CONF_FUNCTION, default={CONF_NAME: "Function", CONF_MODE: "BOX"}): number.number_schema(
             CustomNumber,
             entity_category=ENTITY_CATEGORY_CONFIG
@@ -244,6 +272,35 @@ async def to_code(config: ConfigType) -> None:
 
     cg.add(var.set_temperature_controller_address(config[CONF_TEMPERATURE_CONTROLLER_ADDRESS]))
     cg.add(var.set_ignore_lock(config[CONF_IGNORE_LOCK]))
+
+    # Apply feature negotiation overrides. Anything omitted from YAML keeps the
+    # in-code DefaultFeatures value.
+    if CONF_AUTOCONF in config:
+        cg.add(var.set_autoconf(config[CONF_AUTOCONF]))
+    if CONF_SUPPORTED_MODES in config:
+        modes = set(config[CONF_SUPPORTED_MODES])
+        cg.add(var.set_supported_modes(
+            "AUTO" in modes, "HEAT" in modes, "FAN" in modes, "DRY" in modes, "COOL" in modes
+        ))
+    if CONF_SUPPORTED_FAN_MODES in config:
+        fan_modes = set(config[CONF_SUPPORTED_FAN_MODES])
+        cg.add(var.set_supported_fan_modes(
+            "QUIET" in fan_modes, "LOW" in fan_modes, "MEDIUM" in fan_modes,
+            "HIGH" in fan_modes, "AUTO" in fan_modes
+        ))
+    if CONF_SUPPORTED_SWING_MODES in config:
+        swing_modes = set(config[CONF_SUPPORTED_SWING_MODES])
+        vertical = "VERTICAL" in swing_modes or "BOTH" in swing_modes
+        horizontal = "HORIZONTAL" in swing_modes or "BOTH" in swing_modes
+        cg.add(var.set_supported_swing_modes(vertical, horizontal))
+    if CONF_FILTER_TIMER in config:
+        cg.add(var.set_filter_timer(config[CONF_FILTER_TIMER]))
+    if CONF_SENSOR_SWITCHING in config:
+        cg.add(var.set_sensor_switching(config[CONF_SENSOR_SWITCHING]))
+    if CONF_MAINTENANCE in config:
+        cg.add(var.set_maintenance(config[CONF_MAINTENANCE]))
+    if CONF_ECONOMY_MODE in config:
+        cg.add(var.set_economy_mode(config[CONF_ECONOMY_MODE]))
 
     varx = cg.Pvariable(config[CONF_STANDBY_MODE][CONF_ID], var.standby_sensor)
     await binary_sensor.register_binary_sensor(varx, config[CONF_STANDBY_MODE])

--- a/components/fujitsu-halcyon/esphome-fujitsu-halcyon.cpp
+++ b/components/fujitsu-halcyon/esphome-fujitsu-halcyon.cpp
@@ -48,6 +48,14 @@ void FujitsuHalcyonController::setup() {
         }
     );
 
+    // Apply user-supplied feature overrides from YAML. features_override_ was
+    // initialized to DefaultFeatures and individually mutated by any setters
+    // called from to_code(); fields the user did not specify still hold their
+    // DefaultFeatures value. Must be applied before the first packet is processed;
+    // setup() runs before loop() so this is safe.
+    this->controller->set_features(this->features_override_);
+    this->controller->set_autoconf(this->autoconf_);
+
     this->connected_sensor->publish_state(false);
 
     // Use specified sensor for this components reported temperature

--- a/components/fujitsu-halcyon/esphome-fujitsu-halcyon.h
+++ b/components/fujitsu-halcyon/esphome-fujitsu-halcyon.h
@@ -72,12 +72,44 @@ class FujitsuHalcyonController : public Component, public climate::Climate, publ
         void set_temperature_sensor(sensor::Sensor* temperature_sensor) { this->temperature_sensor_ = temperature_sensor; }
         void set_temperature_controller_address(uint8_t temperature_controller_address) { this->temperature_controller_address_ = temperature_controller_address; }
 
+        // Feature negotiation overrides (called from to_code() in climate.py).
+        // Setters mutate features_override_ in place; fields not touched keep the
+        // DefaultFeatures value the struct was initialized with.
+        void set_autoconf(bool v) { this->autoconf_ = v; }
+        void set_supported_modes(bool a, bool h, bool f, bool d, bool c) {
+            this->features_override_.Mode.Auto = a;
+            this->features_override_.Mode.Heat = h;
+            this->features_override_.Mode.Fan  = f;
+            this->features_override_.Mode.Dry  = d;
+            this->features_override_.Mode.Cool = c;
+        }
+        void set_supported_fan_modes(bool q, bool l, bool m, bool h, bool a) {
+            this->features_override_.FanSpeed.Quiet  = q;
+            this->features_override_.FanSpeed.Low    = l;
+            this->features_override_.FanSpeed.Medium = m;
+            this->features_override_.FanSpeed.High   = h;
+            this->features_override_.FanSpeed.Auto   = a;
+        }
+        void set_supported_swing_modes(bool vert, bool horiz) {
+            this->features_override_.VerticalLouvers   = vert;
+            this->features_override_.HorizontalLouvers = horiz;
+        }
+        void set_filter_timer(bool v)     { this->features_override_.FilterTimer     = v; }
+        void set_sensor_switching(bool v) { this->features_override_.SensorSwitching = v; }
+        void set_maintenance(bool v)      { this->features_override_.Maintenance     = v; }
+        void set_economy_mode(bool v)     { this->features_override_.EconomyMode     = v; }
+
     protected:
         uint8_t controller_address_{};
         uint8_t temperature_controller_address_{};
         bool ignore_lock_{};
         sensor::Sensor* humidity_sensor_{};
         sensor::Sensor* temperature_sensor_{};
+
+        // Feature negotiation state. Initialized to DefaultFeatures so anything not
+        // overridden by YAML keeps the in-code default. Applied to Controller in setup().
+        bool autoconf_ = true;
+        fujitsu_general::airstage::h::Features features_override_ = fujitsu_general::airstage::h::DefaultFeatures;
 
     private:
         fujitsu_general::airstage::h::Controller* controller;


### PR DESCRIPTION
Closes #35

This PR addresses indoor units that don't support feature negotiation, building on the discussion in the linked issue.

**Three commits**:

1. **Advance initialization on Config received during FeatureRequest stage**
   When the IU ignores a `FeatureRequest` and keeps replying with `Config`, the first such `Config` is treated as the signal that negotiation isn't supported. Implements the consolidated condition you suggested in the issue thread.

2. **Add YAML autoconf and per-feature overrides**
   New climate.py options modeled on the Midea component:
   - `autoconf` (default `true`) — set to `false` to skip the `FeatureRequest` probe entirely (for units known to enter a non-recoverable error state when probed).
   - `supported_modes`, `supported_fan_modes`, `supported_swing_modes` — list-based group overrides.
   - `filter_timer`, `sensor_switching`, `maintenance`, `economy_mode` — per-feature boolean overrides.

   Anything not specified keeps the in-code `DefaultFeatures` value, so existing user configurations behave identically.

3. **README: document autoconf and per-feature overrides**
   New section with worked example and behavior matrix.

**Tested on** Fujitsu ASHA07LACM (UnknownFlags=5, never replies with Features). Initialization completes normally and the climate entity behaves as expected.

Happy to squash to a single commit if you prefer.
